### PR TITLE
Handle 0-length tar files that docker can place in it's archives.

### DIFF
--- a/export/utils.go
+++ b/export/utils.go
@@ -16,6 +16,15 @@ import (
 // Extracts a tar-file with the correct permissions to expand a docker
 // image layer.
 func ExtractTar(src, dest string) ([]byte, error) {
+	// Docker likes to produce 0-length tar files in save files. These will
+	// *fail* to extract with tar, but are valid (i.e. an empty directory should
+	// result. Catch that situation here and return success.
+	if st, err := os.Stat(src) ; st.Size() == 0 {
+		return []byte{}, nil
+	} else if err != nil {
+		return []byte{}, err
+	}
+
 	cmd := exec.Command("tar", "--same-owner", "--xattrs", "--overwrite",
 		"--preserve-permissions", "-xf", src, "-C", dest)
 	return cmd.CombinedOutput()


### PR DESCRIPTION
Layers with 0-length tar archives (which appear to be valid for docker) would
fail to extract previously. We should instead handle them as successes when
doing a tar-file extraction.